### PR TITLE
Add Makefile to pytest and pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# NOTE: This file MUST use tabs for indentation rather than spaces
+#       If you get an error "*** missing separator. Stop" then you
+#       probably have spaces for indentation.
+export PATH:=${PWD}/.venv/bin:${PATH};
+
+all: test static
+
+test:
+	pytest;
+
+static:
+	pylint --rcfile=.pylintrc *.py;
+
+clean:
+	# Find and remove all files and  folders that match
+    # -E for extended grep to match the pattern
+	-find . | grep -E "(__pycache__|\.pyc)" | xargs rm -rf
+    # -w for whole word match
+	-find . | grep -w ".pytest_cache" | xargs rm -rf


### PR DESCRIPTION
The Makefile will test and lint the system using just one command so you can make sure that your code passes all tests and is compliant before pushing your changes. In your terminal, just use the command `make` and it will run pytest and pylint. It will also clean up some folders that we do not need. 