### PR TITLE
add HTTPS for dev and prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# ssl credentials
+*.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,11 @@ services:
     # in docker-compose, paths are relative to the docker-compose file
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ${CERT}
+      - ${KEY}
     ports:
       - "80:80"
+      - "443:443"
     # specify that the flask_api container must be running before the nginx container
     depends_on:
       - api

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,6 +58,52 @@ FIXME this needs to be automated.
 pylint [ filename ]
 '''
 
+## Setup HTTPS for Development
+
+* Starting from the root directory make your way to the nginx folder
+
+```
+cd nginx
+```
+
+* create a folder named certs in the nginx folder
+
+```
+mkdir certs
+```
+
+* enter the certs folder
+
+```
+cd certs
+```
+
+* Run this on the command line to creat the necessary cert and priv key
+* It is IMPERITAVE you are in the certs folder at this time
+
+```
+openssl req -x509 -newkey rsa:4096 -nodes -out fullchain.pem -keyout privkey.pem -days 365
+```
+
+* Return to the root directory
+
+```
+cd ../..
+```
+
+* Create a .env file
+* inside the .env file paste
+
+```
+CERT=./nginx/certs/fullchain.pem:/etc/nginx/certs/fullchain.pem
+KEY=./nginx/certs/privkey.pem:/etc/nginx/certs/privkey.pem
+```
+
+Because we are using self signed certs for development when you go to 
+`https://localhost` you will have to hit the advanced settings to continue
+because your browser will pick up that it is not 3rd party authenticated.
+Chrome is a little more strict about this so you may be better off using
+safari or another browser. 
 
 ## Deploy the System in Development
 
@@ -79,7 +125,7 @@ To launch the entire system:
 
   At this point you will have access to:
 
-  * `http://localhost` - Interact through the NGINX server.  Requests will be routed to the Node (React) server or the Flask (API) server, as appropriate.
+  * `https://localhost` - Interact through the NGINX server.  Requests will be routed to the Node (React) server or the Flask (API) server, as appropriate.
   * `http://localhost:8000` - direct access to the Flask (API) server.
   * `http://localhost:3000` - diredt access to the React server.
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -2,16 +2,16 @@
 
 * Build docker container
 '''
-./build.sh
+sudo docker-compose build
 '''
 
 * Run docker container
 '''
-./up.sh
+sudo docker-compose up -d
 '''
 
 * Bring the conatiner down
 '''
-./down.sh
+sudo docker-compose down
 '''
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,8 +1,11 @@
 # This file comes from the Flask documentation
 # https://flask.palletsprojects.com/en/2.3.x/deploying/nginx/
 server {
-    listen 80;
+    listen 443 ssl;
     server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
 
     location /api {
         # All traffic starting with `/api`


### PR DESCRIPTION
docker-compose.yml
   - opened port 443
   - mounted env variables named CERT and KEY

nginx/default.conf
   - listening on port 443 ssl instead of port 80
   - ssl certificate and key filepath mounted

.gitignore
   - added *.pem

docs/development.md
   - added instructions for creating self signed cert
   - added instructions on the creation of .env file

docs/production.md
   - updated to using docker-compose instead of bash scripts

The self signed certs made with openssl will need to be put in a folder named certs in the nginx folder.
Upon creation they will be named fullchain.pem and privkey.pem. This way they will match up with our certs 
made by certbot. This needed to be done because nginx config files do not accept environment variables so 
the mounts in the default.conf file needed to match in both production and development. The development.md file conatins step by step instruction on how to set this up on your own machines.