### PR TITLE
Add API endpoint to search dockets

### DIFF
--- a/api/src/mirrsearch/api/app.py
+++ b/api/src/mirrsearch/api/app.py
@@ -24,15 +24,18 @@ def create_app():
     @app.route('/search_dockets')
     def search_dockets():
        response = {}
+
+       # Obtains the search term
        search_term = request.args.get('term')
 
+        # If a search term is not provided, the server will return this message
        if search_term is None or len(search_term) == 0:
            response['error'] = {'code': 400, 'message': 'Error: You must provide a term to be searched'}
            return jsonify(response)
       
+      # If the search term is valid, data will be ingested into the JSON response
        response['data'] = {'search_term': search_term}
        response['data']['dockets'] = []
-       # TODO: insert the data with presentation term
        response['data']['dockets'].append({
            'title': 'Designation as a Preexisting Subscription Service',
            'id': "COLC-2006-0014",

--- a/api/src/mirrsearch/api/app.py
+++ b/api/src/mirrsearch/api/app.py
@@ -3,7 +3,7 @@ Create barebones Flask app
 Run with: python kickoff_app.py
 """
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 
 
@@ -20,6 +20,28 @@ def create_app():
     def get_data():
         data = {"message": "hello world", "status": 200}
         return jsonify(data)
+    
+    @app.route('/search_dockets')
+    def search_dockets():
+       response = {}
+       search_term = request.args.get('term')
+
+       if search_term is None or len(search_term) == 0:
+           response['error'] = {'code': 400, 'message': 'Error: You must provide a term to be searched'}
+           return jsonify(response)
+      
+       response['data'] = {'search_term': search_term}
+       response['data']['dockets'] = []
+       # TODO: insert the data with presentation term
+       response['data']['dockets'].append({
+           'title': 'Designation as a Preexisting Subscription Service',
+           'id': "COLC-2006-0014",
+           'link': 'https://www.regulations.gov/docket/COLC-2006-0014',
+           'number_of_comments': 0,
+           'number_of_documents': 1
+           })
+       return jsonify(response)
+
     return app
 
 def launch():

--- a/api/tests/test_app.py
+++ b/api/tests/test_app.py
@@ -53,3 +53,24 @@ def test_data_endpoint_returns_status(client):
     response = client.get('/data')
     data = json.loads(response.data)
     assert 'status' in data
+
+# Test whether the search_dockets endpoint returns a 200 status code.
+def test_search_dockets_endpoint_returns_status(client):
+    search_term = 'meaningful+use'
+    response = client.get(f'/search_dockets?term={search_term}')
+    assert response.status_code == 200
+
+
+def test_search_dockets_endpoint_returns_valid_json(client):
+    search_term = 'meaningful+use'
+    response = client.get(f'/search_dockets?term={search_term}')
+    assert response.is_json
+
+def test_search_dockets_endpoint_returns_data_key(client):
+    search_term = 'meaningful+use'
+    response = client.get(f'/search_dockets?term={search_term}')
+    assert 'data' in response.data
+
+def test_search_dockets_endpoint_returns_status_code_400(client):
+    response = client.get('/search_dockets')
+    assert response.status_code == 400

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,7 +22,7 @@ All API calls will return a JSON response type that contains each docket that ha
     "dockets": [
       {
         "title": "string",
-        "id": "integer",
+        "id": "string",
         "link": "string",
         "number_of_comments": "int",
         "number_of_documents": "int"
@@ -71,7 +71,7 @@ All API calls will return a JSON response type that contains each docket that ha
             "date_posted": "date",
             "document_type": "string",
             "link": "string",
-	    "docket_id": "integer"
+	    "docket_id": "string"
       }
     ]
   }
@@ -118,7 +118,7 @@ All API calls will return a JSON response type that contains each docket that ha
         "author": "string",
         "date_posted": "date",
         "link": "string",
-  "docket_id": "integer"
+        "docket_id": "string"
       }
     ]
   }


### PR DESCRIPTION
Implemented API endpoint called /search_dockets that takes a query parameter 'term' to be searched. Tests for the endpoint were added to the test_app Python program. Documentation was also updated for the API to fix the return type for docket IDs. 

The endpoint is currently hard-coded to return the search for "preexisting subscription" on regulations.gov. If we choose to use a different term for the presentation, this will need to be changed as well.