### PR TITLE
Fix bug in EC2 instance where data attribute was being accessed twice

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,8 +10,8 @@ function App() {
   const handleOnClick = async () => {
     console.log("Hello");
     const data = await getDummyData();
-    console.log(data.data.dockets);
-    setDockets(data.data.dockets); // Set docket state to true when search button is clicked
+    console.log(data.dockets);
+    setDockets(data.dockets); // Set docket state to true when search button is clicked
   };
 
   return (


### PR DESCRIPTION
Locally, the data was only able to be accessed by drilling into a secondary .data attribute, but on the EC2 instance this causes an error. 