### PR TITLE
remove mongo image from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,17 +26,9 @@ services:
     depends_on:
       - api
       - frontend
-      - mongo
     # specify that logging should be managed in a rotating basis
     logging:
       driver: "local"
       options:
         max-size: "10m"
-  mongo:
-    image: mongodb/mongodb-community-server:6.0-ubi8
-    volumes:
-      - type: bind
-        source: ./data
-        target: /data/db
-    ports:
-      - "27017:27017"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,15 @@ services:
     depends_on:
       - api
       - frontend
+      - mongo
     # specify that logging should be managed in a rotating basis
     logging:
       driver: "local"
       options:
         max-size: "10m"
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+    
 


### PR DESCRIPTION
This removes the mongo image from the docker-compose.yml file.
Will return our upstream main to working upon merge.
This won't affect the work that has been done towards mongo we will just get back to green and make new progress from there with getting our mongo instance set up with our system. 