### PR TITLE
Modified npm install to reduce build time

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install
+RUN npm install package.json
 
 CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,12 +2,13 @@
 
 # Path: react-app/Dockerfile
 # Compare this snippet from Dockerfile:
-FROM node:16.13.0-alpine3.14
+FROM node:16.14.0-alpine3.14
 
 WORKDIR /app
 
 COPY . .
 
-RUN npm install package.json
+RUN npm install -g pnpm
+RUN pnpm install
 
 CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,13 +2,15 @@
 
 # Path: react-app/Dockerfile
 # Compare this snippet from Dockerfile:
-FROM node:16.14.0-alpine3.14
+FROM node:16.13.0-alpine3.14
 
 WORKDIR /app
 
-COPY . .
+EXPOSE 3000
 
-RUN npm install -g pnpm
-RUN pnpm install
+COPY package.json /app
+RUN npm install
+
+COPY . /app
 
 CMD ["npm", "start"]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,7 +8,7 @@ function App() {
   const [dockets, setDockets] = useState(); // Initialize docket state to false
 
   const handleOnClick = async () => {
-    console.log("Hello");
+    // console.log("Hello");
     const data = await getDummyData();
     console.log(data.data.dockets);
     setDockets(data.data.dockets); // Set docket state to true when search button is clicked


### PR DESCRIPTION
This is a test PR to see if we can improve build time. As of now I am not sure if this is faster currently than what is in production. I swapped out the wildcard `npm install` and rather specified with our `package.json` file.

I would appreciate if some others could play around and see if there is a way to improve the build time of our node application. The current throttle is getting the required `node_modules` folder into the container. You either need to do the one time install originally and use the version of `node_modules` being copied over by docker, or have it generated by the install command.

I have found that the copying works a lot faster in the long run, but I am not 100% sure of this