### PR TITLE
Fixed websocket error in DOM

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -56,6 +56,22 @@ In order to use any of these commands, you must be in the root of the project.
   * `pytest` uses a 95% coverage metric
   * Run `open htmlcov/index.html` in order to see the coverage report
 
+## House-cleaning for Front-end
+
+* Navigate to the frontend directory
+
+```
+cd frontend
+```
+
+* Make a `.env` file
+
+```
+nano .env
+```
+
+* Add the line `WDS_SOCKET_PORT=0` and save
+
 ## Setup HTTPS for Development
 
 * Starting from the root directory make your way to the nginx folder

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -34,4 +34,12 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Prefix /;
     }
+
+    location /ws {
+        # Websockets are proxied to the `frontend` container
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
 }


### PR DESCRIPTION
I found a websocket error related to the NGINX configuration alongside React. I believe this fix should work. A .env file is needed inside of the front end directory with `WDS_SOCKET_PORT=0`, as well as adding another reverse proxy for websocket traffic.