### PR TITLE
Change mongo image to unspecified version tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ yarn-error.log*
 
 # ssl credentials
 *.pem
+
+#db
+sample-data/
+sample.zip
+api/data/
+data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       options:
         max-size: "10m"
   mongo:
-    image: mongodb/mongodb-community-server:6.0-ubi8
+    image: mongo
     volumes:
       - type: bind
         source: ./data


### PR DESCRIPTION
Change image to not use a version tag. It will default to the latest version available and offer more stability.
Add sample-data and other related data files to .gitignore