### PR TITLE
Added ID index for text-based documents, allowing for search via ID

### DIFF
--- a/api/src/mirrsearch/db/mongo_db.py
+++ b/api/src/mirrsearch/db/mongo_db.py
@@ -26,19 +26,20 @@ def connect_to_mongodb():
     database.create_collection('comments')
     return database, client
 
+
 def insert_json_data(collection, data):
     """ Function to insert data into collections """
     collection.insert_one(data['data'])
 
 
-def insert_txt_data(collection, data):
+def insert_txt_data(collection, data, docket_id):
     """ Function to insert data into collections """
-    collection.insert_one({'data': data})
+    collection.insert_one({'id':docket_id, 'data': data})
 
 
 # This function is currently bypassing utf-8 encoding errors by ignoring them for .htm files
 # This is not a good solution, but it is a temporary fix for the time being
-def insert_docket_file(file, collection):
+def insert_docket_file(file, collection, docket_id):
     """ Function to insert a JSON or HTM file into a collection """
     if file.endswith('.json'):
         with open(file, 'r', encoding='utf-8') as f:
@@ -47,12 +48,12 @@ def insert_docket_file(file, collection):
     if file.endswith('.txt'):
         with open(file, 'r', encoding='utf-8') as f:
             data = f.read()
-            insert_txt_data(collection, data)
+            insert_txt_data(collection, data, docket_id)
     if file.endswith('.htm'):
         # The below line is a temporary fix for the time being to get .htm files loaded
         with open(file, 'r', encoding='utf-8', errors="ignore") as f:
             data = f.read()
-            insert_txt_data(collection, data)
+            insert_txt_data(collection, data, docket_id)
 
 
 def add_data_to_database(root_folder, database):
@@ -61,15 +62,18 @@ def add_data_to_database(root_folder, database):
         if root.split('/')[-1] == 'docket':
             for file in files:
                 if file.endswith('.json') or file.endswith('.txt') or file.endswith('.htm'):
-                    insert_docket_file(os.path.join(root, file), database['docket'])
+                    docket_id = root.split('/')[-3]
+                    insert_docket_file(os.path.join(root, file), database['docket'], docket_id)
         if root.split('/')[-1] == 'comments':
             for file in files:
                 if file.endswith('.json') or file.endswith('.txt') or file.endswith('.htm'):
-                    insert_docket_file(os.path.join(root, file), database['comments'])
+                    docket_id = root.split('/')[-3]
+                    insert_docket_file(os.path.join(root, file), database['comments'], docket_id)
         if root.split('/')[-1] == 'documents':
             for file in files:
                 if file.endswith('.json') or file.endswith('.txt') or file.endswith('.htm'):
-                    insert_docket_file(os.path.join(root, file), database['documents'])
+                    docket_id = root.split('/')[-3]
+                    insert_docket_file(os.path.join(root, file), database['documents'], docket_id)
 
 
 def clear_db(database):

--- a/api/src/mirrsearch/db/mongo_db.py
+++ b/api/src/mirrsearch/db/mongo_db.py
@@ -8,23 +8,22 @@ import json
 from pymongo import MongoClient
 
 
-# Connection URI
-URI = 'mongodb://localhost:27017'
-
-# Database Name
-DB_NAME = 'mongoSample'
-
-
 def connect_to_mongodb():
     """ Function to connect to MongoDB and ensure collections exist """
     client = MongoClient(URI)
-    database = client[DB_NAME]
-
-    clear_db(database)
+    database = clear_db(client)
     database.create_collection('docket')
     database.create_collection('documents')
     database.create_collection('comments')
     return database, client
+
+
+def clear_db(client):
+    """ Function to clear all collections in the database """
+    database = client['mirrsearch']
+    for collection in database.list_collection_names():
+        database[collection].drop()
+    return database
 
 
 def insert_json_data(collection, data):
@@ -76,13 +75,8 @@ def add_data_to_database(root_folder, database):
                     insert_docket_file(os.path.join(root, file), database['documents'], docket_id)
 
 
-def clear_db(database):
-    """ Function to clear all collections in the database """
-    for collection in database.list_collection_names():
-        database[collection].drop()
-
-
 if __name__ == "__main__":
+    URI = 'mongodb://localhost:27017'
     database, client = connect_to_mongodb()
     add_data_to_database('sample-data', database)
     client.close()

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,55 +164,41 @@ To launch the entire system:
 
 Prerequisite: Have the system running in by following [Deploy the System in Development]
 
-1. Navigate to the api folder
+1. Navigate to the api folder and activate your virtual environment
 ```
 cd api
-```
-
-2. Activate virtual environment
-```
 source .venv/bin/activate
 ```
 
-3. Navigate to MongoDB script directory
+2. Navigate to MongoDB script directory
 ```
 cd src/mirrsearch/db
 ```
 
-4.  Ensure that you have unzipped sample-data.zip to this directory and make sure the unzipped folder is named sample-data and contains two folders named CRB and IHS.
+3.  Ensure that you have unzipped our [sample-data](https://drive.google.com/drive/folders/1CsC3CKY0a52ZBI0_2558-No6Ke-UZw_s?usp=drive_link) to this directory, into a folder called `sample-data` that contains the names of various organizations such as "IHS" and "CRB" as parent folders.
   
   - To check if you have mongosh run 'brew list | grep mongosh'
   - If you do not have mongosh installed run 'brew install mongosh'
 
-5. Run the Mongo_DB.py script to ingest the data:
+4. Run the `mongo_db.py` script to ingest the data:
 ```
 python3 mongo_db.py
 ```
-6. The data should be in the database now. To check use a new terminal and follow these steps:
+5. The data is now ingested within the `mirrsearch` database inside of `Mongo`. To access the data, follow these steps:
 
   - Launch the MongoDB shell:
 ```
 mongosh
 ```
-  - List available databases:
+
+  - List available dbs and switch to the `mirrsearch` database:
 ```
 show dbs
-```
-  - Switch to the mongoSample database:
-```
-use mongoSample
+use mirrsearch
 ```
 
-  - List the collection in the mongoSample database:
+  - You can list all collections within the `mirrsearch`. You can then view the contents of a collection type:
 ```
 show collections
-```
-
-  - You should see comments, docket, documents. To view the contents of a collection type:
-```
 db.collectionName.find()
-```
-  For example:
-```
-db.comments.find()
 ```


### PR DESCRIPTION
I have added a `id` tag onto text documents to allow for easier accessing via our API interface. You should now be able to get a comprehensive query across dockets, comments, and documents all whilst using the `docket_id` as the key for your search.