### PR TITLE
Updated pytest.ini to ignore setup and mongo insertion code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ exclude_lines =
 [run]
 omit = 
     ./api/src/mirrsearch/db/*
+    ./api/setup.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,7 @@
 
 exclude_lines =
     if __name__ == .__main__.:
+
+[run]
+omit = 
+    ./api/src/mirrsearch/db/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,7 @@
 [pytest]
 testpaths = api/tests
 junit_family=xunit1
-addopts = --cov=api/
-    --ignore=mongo_db.py
-    --ignore=setup.py
+addopts = --cov=api/src/mirrsearch
     --cov-fail-under=95
     --cov-report html
     --junitxml=unit-python.xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 testpaths = api/tests
 junit_family=xunit1
 addopts = --cov=api/
+    --ignore=mongo_db.py
+    --ignore=setup.py
     --cov-fail-under=95
     --cov-report html
     --junitxml=unit-python.xml


### PR DESCRIPTION
I am working towards trying to get the test coverage metric a bit higher. This PR is a test to see if we can get coverage to raise from ignoring certain directories and files that do not need test coverage.