### PR TITLE
Updated dev setup to reflect node pre-req

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -125,6 +125,23 @@ because your browser will pick up that it is not 3rd party authenticated.
 Chrome is a little more strict about this so you may be better off using
 safari or another browser. 
 
+## Installing Node Dependencies for Front-End
+
+To run our `front-end` container within docker, you will need to install Node onto your laptop as a pre-requisite:
+
+  ```
+  brew install node
+  ```
+
+Navigate to the `frontend` folder and run the command:
+```
+cd frontend
+npm install
+```
+
+This will generate a folder called `node_modules`, as well as a `package-lock.json` that are necessary for the build process of the front-end container.
+
+
 ## Deploy the System in Development
 
 To launch the entire system:


### PR DESCRIPTION
Since refactoring the way in which our node container is built for our dockerized system, I updated the documentation in the `development.md` file to reflect the process needed to get this working.

It involves installing node and manually running an `npm install` as a one time thing for setup inside of the `frontend` folder.