### PR TITLE
Update docket link to correct URL

### DIFF
--- a/api/src/mirrsearch/api/query_manager.py
+++ b/api/src/mirrsearch/api/query_manager.py
@@ -40,7 +40,7 @@ class MongoQueryManager(QueryManager):
         for doc in search:
             title = doc['attributes']['title']
             doc_id = doc['id']
-            link = doc['links']['self']
+            link = "https://www.regulations.gov/docket/" + doc_id
             number_of_comments = 0  # Placeholder for counting comments
             number_of_documents = 0  # Placeholder for counting documents
             response['data']['dockets'].append({

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,7 +10,6 @@ function App() {
 
  const handleOnClick = async (term) => {
   const data = await getDummyData(term);
-  console.log("deploy test");
   setDockets(data.data.dockets);
  };
 


### PR DESCRIPTION
Corrected the link so that it takes you to the regulations.gov page for a docket when you click on the docket ID. I also removed the console.log that tested the github action deployment. 