### PR TITLE
Add pagination for dockets

### DIFF
--- a/api/src/mirrsearch/api/app.py
+++ b/api/src/mirrsearch/api/app.py
@@ -34,20 +34,15 @@ def create_app(query_manager):
         # Obtains the search term and page number
         search_term = request.args.get('term')
         page = request.args.get('page')
-        page = int(page)
+
+         # If a page number is not provided, the page number will default to 1
+        page = int(page) if page else 1
 
         # If a search term is not provided, the server will return this JSON and a 400 status code
         if not search_term:
             response = {}
             response['error'] = {'code': 400,
                                  'message': 'Error: You must provide a term to be searched'}
-            return jsonify(response), 400
-
-        # If a page number is not provided, the server will return this JSON and a 400 status code
-        if not page:
-            response = {}
-            response['error'] = {'code': 400,
-                                 'message': 'Error: You must provide a page number to be searched'}
             return jsonify(response), 400
 
         # If the search term is valid, data will be ingested into the JSON response

--- a/api/src/mirrsearch/api/app.py
+++ b/api/src/mirrsearch/api/app.py
@@ -31,8 +31,10 @@ def create_app(query_manager):
 
     @app.route('/search_dockets')
     def search_dockets():
-        # Obtains the search term
+        # Obtains the search term and page number
         search_term = request.args.get('term')
+        page = request.args.get('page')
+        page = int(page)
 
         # If a search term is not provided, the server will return this JSON and a 400 status code
         if not search_term:
@@ -41,9 +43,15 @@ def create_app(query_manager):
                                  'message': 'Error: You must provide a term to be searched'}
             return jsonify(response), 400
 
+        # If a page number is not provided, the server will return this JSON and a 400 status code
+        if not page:
+            response = {}
+            response['error'] = {'code': 400,
+                                 'message': 'Error: You must provide a page number to be searched'}
+            return jsonify(response), 400
 
         # If the search term is valid, data will be ingested into the JSON response
-        response = query_manager.search_dockets(search_term)
+        response = query_manager.search_dockets(search_term, page)
 
         return jsonify(response)
 

--- a/api/src/mirrsearch/api/database_manager.py
+++ b/api/src/mirrsearch/api/database_manager.py
@@ -7,6 +7,8 @@ can also be created using this class.
 from pymongo import MongoClient
 from mirrsearch.api.mock_database_manager import MockMongoDatabase
 
+RESULTS_PER_PAGE = 10
+
 class DatabaseManager:
     """
     Class that manages the connection to a database
@@ -51,16 +53,17 @@ class MongoManager(DatabaseManager):
     """
     __instance = None
 
-    def search_dockets(self, search_term):
+    def search_dockets(self, search_term, page):
         """
         Function that searches the dockets collection in the database
         for a given search term
-        """
+        """        
         client = self.get_instance()
         db = client.get_database('mirrsearch')
         dockets = db.get_collection('docket')
 
-        query = dockets.find({'attributes.title': {'$regex': f'{search_term}'}})
+        skipNum = (page - 1) * RESULTS_PER_PAGE
+        query = dockets.find({'attributes.title': {'$regex': f'{search_term}'}}).limit(RESULTS_PER_PAGE).skip(skipNum)
 
         results = []
         for doc in query:

--- a/api/src/mirrsearch/api/query_manager.py
+++ b/api/src/mirrsearch/api/query_manager.py
@@ -30,13 +30,13 @@ class MongoQueryManager(QueryManager):
     Class for managing queries to a MongoDB database
     """
 
-    def search_dockets(self, search_term):
+    def search_dockets(self, search_term, page):
         """
         Function that searches the dockets collection in the database
         for a given search term
         """
         response = {'data': {'search_term': search_term, 'dockets': []}}
-        search = self._manager.search_dockets(search_term)
+        search = self._manager.search_dockets(search_term, page)
         for doc in search:
             title = doc['attributes']['title']
             doc_id = doc['id']


### PR DESCRIPTION
Modified query_manager, database_manager, and app.py to include a page in the parameters. The results are limited to 10 per page and the page variable defines which 10 in the results are displayed.

Not currently complete, front-end does not currently reflect these changes

Restored PR from before repo was deleted