### PR TITLE
Propose new API endpoint

### DIFF
--- a/api/src/mirrsearch/api/app.py
+++ b/api/src/mirrsearch/api/app.py
@@ -29,6 +29,22 @@ def create_app(query_manager):
         trigger_lambda()
         return jsonify(data)
 
+    @app.route('/search')
+    def search():
+        # Obtains the search term
+        search_term = request.args.get('term')
+        response = {}
+
+        # If a search term is not provided, the server will return this JSON and a 400 status code
+        if not search_term:
+            response = {}
+            response['error'] = {'code': 400,
+                                 'message': 'Error: You must provide a term to be searched'}
+            return jsonify(response), 400
+
+        response['data'] = {"search_term": search_term, "status": 200}
+        return jsonify(response)
+
     @app.route('/search_dockets')
     def search_dockets():
         # Obtains the search term

--- a/api/tests/test_app.py
+++ b/api/tests/test_app.py
@@ -184,3 +184,21 @@ def test_zip_data_endpoint_returns_200(client, mocker):
     mocker.patch('mirrsearch.api.app.trigger_lambda')
     response = client.get('/zip_data')
     assert response.status_code == 200
+
+def test_search_endpoint_returns_200(client):
+    """Test whether the search endpoint returns a 200 OK status code."""
+    search_term = 'Governance'
+    response = client.get(f'/search?term={search_term}')
+    assert response.status_code == 200
+
+def test_search_endpoint_returns_valid_json(client):
+    """Test whether the search endpoint returns a valid JSON response."""
+    search_term = 'Governance'
+    response = client.get(f'/search?term={search_term}')
+    assert response.is_json
+
+def test_search_endpoint_returns_400_if_no_search_term(client):
+    """Test whether the search endpoint returns a 400 Bad Request status code
+    when no search term is provided."""
+    response = client.get('/search')
+    assert response.status_code == 400

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ The name for this API endpoint is `/search`. This endpoint uses the other three 
 
 ### Calling the Endpoint
 `/search?term=SEARCH_PARAMETER`
-To call this endpoint, make a request using the example above. When replacing the `term` to be searched, it is important to point out that all search terms are case sensitive. 
+To call this endpoint, make a request using the example above. When replacing the `term` to be searched, it is important to point out that all search terms are **case sensitive**. 
 
 #### Parameters
 `term` - String that contains the search term the user wishes to query.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,57 @@
 # API Documentation
 
+
+## /search
+### Description
+The name for this API endpoint is `/search`. This endpoint uses the other three endpoints below to query their respective collections. 
+
+### Calling the Endpoint
+`/search?term=SEARCH_PARAMETER`
+To call this endpoint, make a request using the example above. When replacing the `term` to be searched, it is important to point out that all search terms are case sensitive. 
+
+#### Parameters
+`term` - String that contains the search term the user wishes to query.
+
+### Endpoint Return
+* `200`<br>
+```
+{
+  "data": {
+    "search_term": "string",
+    "dockets": [
+      {
+        "comment_date_range": "string",
+        "comments_containing": "int,
+        "date_range": "string",
+        "docket_type": "string",
+        "documents_containing": "int",
+        "id": "string",
+        "link": "string",
+        "title": "string",
+        "total_comments": "int",
+        "total_documents": "int"
+      }
+    ]
+  }
+}
+```
+
+* 400
+```
+{
+    "error": {
+        "code": "integer",
+        "message": "string"
+    }
+}
+```
+The response above will be returned for every API call with a 400 status code. If the caller does not provide a search term, the server will return a 400 error because the term was not found.
+
+# ANYTHING BELOW THIS MAY BE OUTDATED
+
 ## /search_dockets
 ### Description
-The name for the API endpoint will be `/search_dockets`. This endpoint will be used to search our database for dockets that contain the specified term and will return all dockets that contain it. Within the dockets, specific comments and documents that contain that term will also be specified. 
+The name for this API endpoint will be `/search_dockets`. This endpoint will be used to search our database for dockets that contain the specified term and will return all dockets that contain it. Within the dockets, specific comments and documents that contain that term will also be specified. 
 
 ### Calling the Endpoint
 `/search_dockets?term=SEARCH_PARAMETER`<br>


### PR DESCRIPTION
Within the API documentations, a new API endpoint
is specified. It is called 'search' and takes a
term that the caller wants to search for.

The new API endpoint will use all three of the
previous endpoints for the search.