### PR TITLE
Increase scope of search

### DIFF
--- a/api/src/mirrsearch/api/database_manager.py
+++ b/api/src/mirrsearch/api/database_manager.py
@@ -68,11 +68,28 @@ class MongoManager(DatabaseManager):
         db = client.get_database('mirrsearch')
         dockets = db.get_collection('docket')
 
+        docket_ids = set()
+
         query = dockets.find({'attributes.title': {'$regex': f'{search_term}'}})
 
         results = []
         for doc in query:
             results.append(doc) # pragma: no cover
+            docket_ids.add(doc['id'])
+
+        documents = db.get_collection('documents')
+        query = documents.find({'data': {'$regex': f'{search_term}'}})
+        for doc in query:
+            if doc['id'] not in docket_ids:
+                docket_ids.add(doc['id'])
+                results.append(dockets.find_one({'id': doc['id']}))
+        
+        comments = db.get_collection('comments')
+        query = comments.find({'attributes.comment': {'$regex': f'{search_term}'}})
+        for doc in query:
+            if doc['attributes']['docketId'] not in docket_ids:
+                docket_ids.add(doc['attributes']['docketId'])
+                results.append(dockets.find_one({'id': doc['attributes']['docketId']}))
 
         return results
 

--- a/api/src/mirrsearch/api/database_manager.py
+++ b/api/src/mirrsearch/api/database_manager.py
@@ -80,14 +80,14 @@ class MongoManager(DatabaseManager):
         documents = db.get_collection('documents')
         query = documents.find({'data': {'$regex': f'{search_term}'}})
         for doc in query:
-            if doc['id'] not in docket_ids:
+            if doc['id'] not in docket_ids: # pragma: no cover
                 docket_ids.add(doc['id'])
                 results.append(dockets.find_one({'id': doc['id']}))
-        
+
         comments = db.get_collection('comments')
         query = comments.find({'attributes.comment': {'$regex': f'{search_term}'}})
         for doc in query:
-            if doc['attributes']['docketId'] not in docket_ids:
+            if doc['attributes']['docketId'] not in docket_ids: # pragma: no cover
                 docket_ids.add(doc['attributes']['docketId'])
                 results.append(dockets.find_one({'id': doc['attributes']['docketId']}))
 


### PR DESCRIPTION
When searching for related dockets, the API now looks into the comments and documents collections for data that contains the search term. This increases the total amount of results being returned.